### PR TITLE
Be more tolerant when multiple files match a mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+- Be more tolerant when multiple files match a mask ([#17](https://github.com/ziotom78/qutedb/pull/17))
+
 # 0.4.0
 
 - Upgrade broken dependencies and support Go modules ([#15](https://github.com/ziotom78/qutedb/pull/15))

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ first (e.g., using the [scoop](https://scoop.sh/) package manager).
 To download all the dependencies, build, and install the package in your
 `$GOPATH/bin` directory, run this command:
 
-    go install cmd/createqdbcfg/createqdbcfg.go
-    go install cmd/qutedb/qutedb.go
+    go build ./...
+    go install ./...
     
 This will add the two executables `qutedb` and `createqdbcfg` in the
 `bin` directory of the `$GOPATH` folder.


### PR DESCRIPTION
Sometimes it happens that more than one file is created by the acquisition software, when really one file should be present. This patch makes the code more tolerant by ignoring the oldest files and returning the last (most recent) one.
